### PR TITLE
Fixes to dependency and jax-utils installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 ### Jax Installation (CPU)
 
-To use a CPU-only powered jax, create a `conda` virtual environment containig `python` and `jax`:
+To use a CPU-only powered jax, create a `conda` virtual environment containing `python` and `jax`:
 ```bash
-conda create -n jax-tutorial python=3.9 numpy scipy jax && conda activate jax-tutorial
-pip install flax numpyro
+conda create -n jax-tutorial python=3.9 && conda activate jax-tutorial
+conda install -c conda-forge numpy scipy jax flax numpyro
 ```
 
 ### Jax Installation (GPU)
@@ -55,9 +55,9 @@ export LD_LIBRARY_PATH=/path/to/cuda/dir/lib64;  # YMMV: might be lib and not li
 
 ### Testing your installation
 
-To test that your jax environment is properly setup, a convenience script is provided as part of this tutorial. Run:
+To test that your jax environment is properly setup, a convenience script is provided as part of this tutorial. From the root directory of this repository run:
 ```bash
-python -m pip install jax-utils
+python -m pip install ./jax-utils
 # if on CPU:
 python -m jax_utils.test_jax_installation
 # if on GPU:


### PR DESCRIPTION
A couple of slight tweaks to installation instructions:

  * `jax` package is only available in `conda-forge` not main `anaconda` channel so corresponding `conda install` command needs a `-c conda-forge` argument; `flax` and `numpyro` are also available as packages in `conda-forge` channel so have changed to install all dependencies using `conda` rather than mixing `conda` and `pip`.
  * Running `python -m pip install jax-utils` returns an error for me due to I think `pip` assuming `jax-utils` is a package to look for on the default index at pypi.org. Adding a `./` to make it explicit this is a path to a directory containing a `setup.py` script fixes (and I also added a note to indicate this command should be run from root of repository directory). 