### PR TITLE
Add Google Colab badge and links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# JAX tutorial
+
+<a href="https://colab.research.google.com/github/pierreglaser/jax-tutorial/blob/main/tutorial.ipynb">
+    <img alt="Open in Colab" src="https://colab.research.google.com/assets/colab-badge.svg" style="vertical-align:text-bottom">
+</a>
+
+The tutorial notebook can be opened and run interactively on [Google Colab](https://colab.research.google.com/) from the badge above. The corresponding notebook with solutions to the exercises can also be run on Google Colab from [this link](https://colab.research.google.com/github/pierreglaser/jax-tutorial/blob/main/tutorial_with_solutions.ipynb). Alternatively follow the instructions below to set up a local Python environment to run the notebook from.
+
 ## Installation Instructions
 
 

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -5,7 +5,25 @@
    "id": "79b3ba15-2375-4efd-97de-1c5fa6e6d2d4",
    "metadata": {},
    "source": [
-    "# Tutorial: JAX"
+    "# Tutorial: JAX\n",
+    "\n",
+    "The cell below will install the additional required dependencies using `pip` if running the notebook on [Google Colab](https://colab.research.google.com/) - it should do nothing if running locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7c2eb1d-0737-486c-8718-c0ad81c52843",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    # Running on Google Colab therefore install additional dependencies\n",
+    "    !pip install flax numpyro\n",
+    "except ImportError:\n",
+    "    # Assume dependencies installed if not running on Colab\n",
+    "    pass"
    ]
   },
   {
@@ -2086,9 +2104,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "jax-tutorial",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "jax-tutorial"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorial_with_solutions.ipynb
+++ b/tutorial_with_solutions.ipynb
@@ -5,7 +5,25 @@
    "id": "79b3ba15-2375-4efd-97de-1c5fa6e6d2d4",
    "metadata": {},
    "source": [
-    "# Tutorial: JAX"
+    "# Tutorial: JAX\n",
+    "\n",
+    "The cell below will install the additional required dependencies using `pip` if running the notebook on [Google Colab](https://colab.research.google.com/) - it should do nothing if running locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc17c4af-1dbb-421a-b9c8-353c835c8698",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import google.colab\n",
+    "    # Running on Google Colab therefore install additional dependencies\n",
+    "    !pip install flax numpyro\n",
+    "except ImportError:\n",
+    "    # Assume dependencies installed if not running on Colab\n",
+    "    pass"
    ]
   },
   {
@@ -2083,9 +2101,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "jax-tutorial",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "jax-tutorial"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Adds links to run tutorial notebook on Google Colab as an alternative to setting up dependencies locally README file.